### PR TITLE
Make TransportAddress of Initiator configurable

### DIFF
--- a/pkg/nvme/initiator.go
+++ b/pkg/nvme/initiator.go
@@ -9,7 +9,6 @@ import (
 
 	"github.com/longhorn/nsfilelock"
 
-	"github.com/longhorn/go-spdk-helper/pkg/types"
 	"github.com/longhorn/go-spdk-helper/pkg/util"
 )
 
@@ -36,20 +35,15 @@ type Initiator struct {
 	logger logrus.FieldLogger
 }
 
-func NewInitiator(subsystemNQN, transportServiceID string) (*Initiator, error) {
-	// localIP, err := util.GetIPToHost()
-	// if err != nil {
-	// 	return err
-	// }
-
+func NewInitiator(subsystemNQN, transportAddress, transportServiceID string) (*Initiator, error) {
 	dev := &Initiator{
 		SubsystemNQN:       subsystemNQN,
-		TransportAddress:   types.LocalIP,
+		TransportAddress:   transportAddress,
 		TransportServiceID: transportServiceID,
 
 		logger: logrus.WithFields(logrus.Fields{
 			"subsystemNQN":       subsystemNQN,
-			"transportAddress":   types.LocalIP,
+			"transportAddress":   transportAddress,
 			"transportServiceID": transportServiceID,
 		}),
 	}

--- a/pkg/types/types.go
+++ b/pkg/types/types.go
@@ -7,8 +7,6 @@ const (
 	DefaultUnixDomainSocketPath = "/var/tmp/spdk.sock"
 
 	MiB = 1 << 20
-
-	LocalIP = "127.0.0.1"
 )
 
 func GetNQN(name string) string {


### PR DESCRIPTION
1. Make TransportAddress of Initiator configurable
~~2. "nvme connect" doesn't support "-o" option~~ => old nvme-clie doesn't support `-o`, will check in the environment check script.