### PR TITLE
types: Add missed const LocalIP

### DIFF
--- a/pkg/types/types.go
+++ b/pkg/types/types.go
@@ -6,6 +6,8 @@ const (
 	DefaultJSONServerNetwork    = "unix"
 	DefaultUnixDomainSocketPath = "/var/tmp/spdk.sock"
 
+	LocalIP = "127.0.0.1"
+
 	MiB = 1 << 20
 )
 


### PR DESCRIPTION
Fix error:
```
# github.com/longhorn/go-spdk-helper/app/cmd/nvmecli
app/cmd/nvmecli/nvmecli.go:32:18: undefined: types.LocalIP
app/cmd/nvmecli/nvmecli.go:70:18: undefined: types.LocalIP
app/cmd/nvmecli/nvmecli.go:129:18: undefined: types.LocalIP
```