### PR TITLE
ReconnectDelaySec can't be more than FastIoFailTimeoutSec

### DIFF
--- a/pkg/types/types.go
+++ b/pkg/types/types.go
@@ -13,8 +13,9 @@ const (
 	FrontendSPDKTCPNvmf     = "spdk-tcp-nvmf"
 	FrontendSPDKTCPBlockdev = "spdk-tcp-blockdev"
 
-	DefaultCtrlrLossTimeoutSec  = 30
-	DefaultReconnectDelaySec    = 30
+	DefaultCtrlrLossTimeoutSec = 30
+	// ReconnectDelaySec can't be more than FastIoFailTimeoutSec
+	DefaultReconnectDelaySec    = 5
 	DefaultFastIoFailTimeoutSec = 15
 )
 


### PR DESCRIPTION
ctrlr_loss_timeout_sec: time to wait until ctrlr is reconnected before deleting ctrlr
reconnect_delay_sec: time to delay a reconnect trial
fast_io_fail_timeout_sec: time to wait until ctrlr is reconnected before failing I/O to ctrlr

A time sequence example is:
- Suppose at 0 seconds, a NVMe-oF controller's connection fails and there are some unfinished I/O requests.

- Between 0 and 15 seconds, these I/O requests are reported as failures and the NVMe-oF controller tries to reconnect.

- At 5 seconds, the NVMe-oF controller successfully reconnects and resumes normal operation.

- If at 5 seconds, the NVMe-oF controller does not successfully reconnect, then it tries to reconnect every 5 seconds until it succeeds or exceeds 30 seconds.

- If at 30 seconds, the NVMe-oF controller still does not successfully reconnect, then it is deleted and cannot be used anymore.