### PR TITLE
Only check jsonRPCError code

### DIFF
--- a/pkg/jsonrpc/types.go
+++ b/pkg/jsonrpc/types.go
@@ -22,10 +22,6 @@ func NewMessage(id uint32, method string, params interface{}) *Message {
 
 type RespErrorMsg string
 
-const (
-	RespErrorMsgNoSuchDevice = "No such device"
-)
-
 type RespErrorCode int32
 
 const (
@@ -53,5 +49,5 @@ func IsJSONRPCRespErrorNoSuchDevice(err error) bool {
 	if !ok {
 		return false
 	}
-	return jsonRPCError.Code == RespErrorCodeNoSuchDevice && jsonRPCError.Message == RespErrorMsgNoSuchDevice
+	return jsonRPCError.Code == RespErrorCodeNoSuchDevice
 }


### PR DESCRIPTION
Error message is not reliable. For example, error code is -19, but the error message can be
```
rpc error: code = Unknown desc = error sending message, id 70658, method bdev_raid_delete, params {Name:pvc-39ce670f-145c-4592-9f2f-df0d29ccc130-e-548f4718}: {
        "code": -19,
        "message": "raid bdev pvc-39ce670f-145c-4592-9f2f-df0d29ccc130-e-548f4718 not found"
}
```
and not always "No such device"