### PR TITLE
Handle controller's resetting and connecting state

### DIFF
--- a/pkg/nvme/initiator.go
+++ b/pkg/nvme/initiator.go
@@ -19,7 +19,7 @@ const (
 	RetryCounts   = 5
 	RetryInterval = 3 * time.Second
 
-	waitDeviceTimeout = 30 * time.Second
+	waitDeviceTimeout = 60 * time.Second
 
 	HostProc = "/host/proc"
 )
@@ -36,9 +36,6 @@ type Initiator struct {
 	NamespaceName  string
 	dev            *util.KernelDevice
 	isUp           bool
-
-	// ControllerLossTimeout int64
-	// FastIOFailTimeout     int64
 
 	hostProc string
 	executor util.Executor
@@ -201,7 +198,7 @@ func (i *Initiator) GetEndpoint() string {
 	return ""
 }
 
-func (i *Initiator) LoadNVMeDeviceInfo() error {
+func (i *Initiator) LoadNVMeDeviceInfo() (err error) {
 	if i.hostProc != "" {
 		lock := nsfilelock.NewLockWithTimeout(util.GetHostNamespacePath(i.hostProc), LockFile, LockTimeout)
 		if err := lock.Lock(); err != nil {

--- a/pkg/nvme/nvmecli.go
+++ b/pkg/nvme/nvmecli.go
@@ -125,9 +125,13 @@ func performNvmeListSubsystems(device string, executor util.Executor) ([]Subsyst
 
 	opts := []string{
 		"list-subsys",
-		device,
 		"-o", "json",
 	}
+
+	if device != "" {
+		opts = append(opts, device)
+	}
+
 	outputStr, err := executor.Execute(nvmeBinary, opts)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
When a controller is in a resetting and connecting state, the device list becomes incomplete and broken. The resulting error causes the engine validation logic to run into an error and leads to volume detachment. To resolve this, if "connecting state" is returned, retry the validation logic in SPDK engine.

Longhorn/longhorn#5744