### PR TITLE
Fix using deprecated option of blockdev command in go-spdk-helper

### DIFF
--- a/app/cmd/basic/nvmf.go
+++ b/app/cmd/basic/nvmf.go
@@ -27,7 +27,6 @@ func NvmfCmd() cli.Command {
 			NvmfSubsystemGetNssCmd(),
 			NvmfSubsystemAddListenerCmd(),
 			NvmfSubsystemRemoveListenerCmd(),
-			NvmfSubsystemRemoveListenerCmd(),
 			NvmfSubsystemGetListenersCmd(),
 		},
 	}

--- a/pkg/util/device.go
+++ b/pkg/util/device.go
@@ -185,7 +185,7 @@ func parseNumber(str string) (int, error) {
 // GetDeviceSectorSize returns the sector size of the given device
 func GetDeviceSectorSize(devPath string, executor *commonNs.Executor) (int64, error) {
 	opts := []string{
-		"--getsize", devPath,
+		"--getsz", devPath,
 	}
 
 	output, err := executor.Execute(BlockdevBinary, opts, types.ExecuteTimeout)


### PR DESCRIPTION
Longhorn 7567

#### Which issue(s) this PR fixes:
<!--
Use `Issue #<issue number>` or `Issue longhorn/longhorn#<issue number>` or `Issue (paste link of issue)`. DON'T use `Fixes #<issue number>` or `Fixes (paste link of issue)`, as it will automatically close the linked issue when the PR is merged.
-->
Issue longhorn/longhorn#7567

#### What this PR does / why we need it:

Fix using deprecated option of blockdev command in go-spdk-helper

#### Special notes for your reviewer:

#### Additional documentation or context
