### PR TITLE
Do not use --force for dmsetup remove command

### DIFF
--- a/pkg/nvme/initiator.go
+++ b/pkg/nvme/initiator.go
@@ -213,7 +213,7 @@ func (i *Initiator) stopWithoutLock(dmDeviceCleanupRequired bool) error {
 	}
 
 	if dmDeviceCleanupRequired {
-		if err := i.removeLinearDmDevice(true, true); err != nil {
+		if err := i.removeLinearDmDevice(false, true); err != nil {
 			return err
 		}
 	}


### PR DESCRIPTION


#### Which issue(s) this PR fixes:
<!--
Use `Issue #<issue number>` or `Issue longhorn/longhorn#<issue number>` or `Issue (paste link of issue)`. DON'T use `Fixes #<issue number>` or `Fixes (paste link of issue)`, as it will automatically close the linked issue when the PR is merged.
-->
Issue Longhorn/longhorn#7615

#### What this PR does / why we need it:

--force is too aggressive and might make dmsetup command stuck.

#### Special notes for your reviewer:

#### Additional documentation or context
