### PR TITLE
Allow dm deferred deletion and update the ctrl-loss-tmo of "nvme connect" to 30 seconds

### DIFF
--- a/app/cmd/basic/bdev_nvme.go
+++ b/app/cmd/basic/bdev_nvme.go
@@ -76,6 +76,11 @@ func BdevNvmeAttachControllerCmd() cli.Command {
 				Usage: "NVMe-oF controller fast I/O fail timeout in seconds for error cases",
 				Value: types.DefaultFastIOFailTimeoutSec,
 			},
+			cli.IntFlag{
+				Name:  "keep_alive_timeout_ms",
+				Usage: "NVMe-oF keep alive timeout in milliseconds",
+				Value: types.DefaultKeepAliveTimeoutMs,
+			},
 		},
 		Action: func(c *cli.Context) {
 			if err := bdevNvmeAttachController(c); err != nil {
@@ -227,7 +232,9 @@ func bdevNvmeSetOptions(c *cli.Context) error {
 		return err
 	}
 
-	bdevNameList, err := spdkCli.BdevNvmeSetOptions(int32(c.Int("ctrlr-loss-timeout-sec")), int32(c.Int("reconnect-delay-sec")), int32(c.Int("fast-io-fail-timeout-sec")), int32(c.Int("transport-ack-timeout")))
+	bdevNameList, err := spdkCli.BdevNvmeSetOptions(int32(c.Int("ctrlr-loss-timeout-sec")),
+		int32(c.Int("reconnect-delay-sec")), int32(c.Int("fast-io-fail-timeout-sec")),
+		int32(c.Int("transport-ack-timeout")), int32(c.Int("keep_alive_timeout_ms")))
 	if err != nil {
 		return err
 	}

--- a/app/cmd/nvmecli/nvmecli.go
+++ b/app/cmd/nvmecli/nvmecli.go
@@ -261,7 +261,7 @@ func stop(c *cli.Context) error {
 		return err
 	}
 
-	if _, err := initiator.Stop(true, true); err != nil {
+	if _, err := initiator.Stop(true, false, true); err != nil {
 		return err
 	}
 

--- a/pkg/nvme/nvmecli.go
+++ b/pkg/nvme/nvmecli.go
@@ -15,6 +15,9 @@ const (
 	nvmeBinary = "nvme"
 
 	DefaultTransportType = "tcp"
+
+	// Set short ctrlLossTimeoutSec for quick response to the controller loss.
+	defaultCtrlLossTimeoutSec = 30
 )
 
 type Device struct {
@@ -303,6 +306,7 @@ func connect(hostID, hostNQN, nqn, transpotType, ip, port string, executor *comm
 		"connect",
 		"-t", transpotType,
 		"--nqn", nqn,
+		"--ctrl-loss-tmo", strconv.Itoa(defaultCtrlLossTimeoutSec),
 		"-o", "json",
 	}
 

--- a/pkg/spdk/client/basic.go
+++ b/pkg/spdk/client/basic.go
@@ -846,7 +846,7 @@ func (c *Client) NvmfSubsystemsGetNss(nqn, bdevName string, nsid uint32) (nsList
 //
 //		"trtype": Required. NVMe-oF target trtype: "tcp", "rdma" or "pcie". "tcp" by default.
 //
-//	 	"adrfam": Required. Address family ("IPv4", "IPv6", "IB", or "FC"). "IPv4" by default.
+//	 	"adrfam": Required. Address family ("ipv4", "ipv6", "ib", or "fc"). "ipv4" by default.
 func (c *Client) NvmfSubsystemAddListener(nqn, traddr, trsvcid string, trtype spdktypes.NvmeTransportType, adrfam spdktypes.NvmeAddressFamily) (created bool, err error) {
 	req := spdktypes.NvmfSubsystemAddListenerRequest{
 		Nqn: nqn,

--- a/pkg/spdk/client/basic.go
+++ b/pkg/spdk/client/basic.go
@@ -615,12 +615,15 @@ func (c *Client) BdevNvmeGetControllers(name string) (controllerInfoList []spdkt
 // "fastIOFailTimeoutSec": Fast I/O failure timeout in seconds
 //
 // "transportAckTimeout": Time to wait ack until retransmission for RDMA or connection close for TCP. Range 0-31 where 0 means use default
-func (c *Client) BdevNvmeSetOptions(ctrlrLossTimeoutSec, reconnectDelaySec, fastIOFailTimeoutSec, transportAckTimeout int32) (result bool, err error) {
+//
+// "keepAliveTimeoutMs": Keep alive timeout in milliseconds.
+func (c *Client) BdevNvmeSetOptions(ctrlrLossTimeoutSec, reconnectDelaySec, fastIOFailTimeoutSec, transportAckTimeout, keepAliveTimeoutMs int32) (result bool, err error) {
 	req := spdktypes.BdevNvmeSetOptionsRequest{
 		CtrlrLossTimeoutSec:  ctrlrLossTimeoutSec,
 		ReconnectDelaySec:    reconnectDelaySec,
 		FastIOFailTimeoutSec: fastIOFailTimeoutSec,
 		TransportAckTimeout:  transportAckTimeout,
+		KeepAliveTimeoutMs:   keepAliveTimeoutMs,
 	}
 
 	cmdOutput, err := c.jsonCli.SendCommand("bdev_nvme_set_options", req)

--- a/pkg/spdk/spdk_test.go
+++ b/pkg/spdk/spdk_test.go
@@ -278,7 +278,7 @@ func (s *TestSuite) TestSPDKBasic(c *C) {
 	c.Assert(dmDeviceBusy, Equals, false)
 	c.Assert(err, IsNil)
 	defer func() {
-		dmDeviceBusy, err = initiator.Stop(true, true)
+		dmDeviceBusy, err = initiator.Stop(true, true, true)
 		c.Assert(dmDeviceBusy, Equals, false)
 		c.Assert(err, IsNil)
 	}()

--- a/pkg/spdk/types/nvme.go
+++ b/pkg/spdk/types/nvme.go
@@ -114,6 +114,7 @@ type BdevNvmeSetOptionsRequest struct {
 	ReconnectDelaySec    int32 `json:"reconnect_delay_sec"`
 	FastIOFailTimeoutSec int32 `json:"fast_io_fail_timeout_sec"`
 	TransportAckTimeout  int32 `json:"transport_ack_timeout"`
+	KeepAliveTimeoutMs   int32 `json:"keep_alive_timeout_ms"`
 }
 
 type BdevNvmeGetControllersRequest struct {

--- a/pkg/types/types.go
+++ b/pkg/types/types.go
@@ -29,6 +29,8 @@ const (
 	// detection, transport_ack_timeout should be set.
 	DefaultTransportAckTimeout = 14
 
+	DefaultKeepAliveTimeoutMs = 10000
+
 	ExecuteTimeout = 60 * time.Second
 )
 


### PR DESCRIPTION
#### Which issue(s) this PR fixes:

Issue Longhorn/longhorn#7697

#### What this PR does / why we need it:

- Allow deferred dm device deletion when deleting a replica
    When deleting a replica, no need to delete a dm device by a blocking method.
- spdk_tgt: add KeepAliveTimeoutMs in BdevNvmeSetOptions
    Add KeepAliveTimeoutMs using the default value 10000 milliseconds as upstream in BdevNvmeSetOptions.
    This is just for making debugging process easier in the future.
- nvme: set ctrl-loss-tmo to 30 seconds for "nvme connect"
    Default ctrl-loss-tmo is 600 seconds which is too long so that the pod deletion will be stuck for 600 seconds when the volume is problematic.
    **Not sure if 30 seconds is a correct value for now. It is just for relieve the stuck case.**
    
    Ref: https://documentation.suse.com/sles/15-SP4/html/SLES-all/cha-nvmeof.html
#### Special notes for your reviewer:

#### Additional documentation or context
