### PR TITLE
(fix)lvol: get_xattr lvol name in BdevLvolGet

### DIFF
--- a/pkg/spdk/client/basic.go
+++ b/pkg/spdk/client/basic.go
@@ -268,11 +268,11 @@ func (c *Client) BdevLvolGet(name string, timeout uint64) (bdevLvolInfoList []sp
 		}
 
 		b.DriverSpecific.Lvol.Xattrs = make(map[string]string)
-		user_created, err := c.BdevLvolGetXattr(name, UserCreated)
+		user_created, err := c.BdevLvolGetXattr(b.Name, UserCreated)
 		if err == nil {
 			b.DriverSpecific.Lvol.Xattrs[UserCreated] = user_created
 		}
-		snapshot_timestamp, err := c.BdevLvolGetXattr(name, SnapshotTimestamp)
+		snapshot_timestamp, err := c.BdevLvolGetXattr(b.Name, SnapshotTimestamp)
 		if err == nil {
 			b.DriverSpecific.Lvol.Xattrs[SnapshotTimestamp] = snapshot_timestamp
 		}


### PR DESCRIPTION
#### Which issue(s) this PR fixes:
Issue #7578

#### What this PR does / why we need it:

When BdevLvolGet is called with lvol name empty, which means to retrieve all bdevs from spdk, the BdevLvolGetXattr function fails. We have to call it with the bdev name retrieved from spdk.

#### Special notes for your reviewer:

#### Additional documentation or context
