### PR TITLE
Fix DetectDevice()

### DIFF
--- a/pkg/util/device.go
+++ b/pkg/util/device.go
@@ -102,7 +102,7 @@ func DetectDevice(path string, executor *commonNs.Executor) (*KernelDevice, erro
 	*/
 
 	opts := []string{
-		"-l", "-n", path, "-o", "NAME,MAJ:MIN",
+		path, "-n", "-o", "NAME,MAJ:MIN", "--nodeps",
 	}
 
 	output, err := executor.Execute(nil, lsblkBinary, opts, types.ExecuteTimeout)


### PR DESCRIPTION
The device should be in the first raw of the device list from "lsblk -l ...". However, The command "lsblk -l ..." unexpectedly sorts the device list, leading to the failure of device detection.

Longhorn/longhorn#7672

#### Which issue(s) this PR fixes:
<!--
Use `Issue #<issue number>` or `Issue longhorn/longhorn#<issue number>` or `Issue (paste link of issue)`. DON'T use `Fixes #<issue number>` or `Fixes (paste link of issue)`, as it will automatically close the linked issue when the PR is merged.
-->
Issue #

#### What this PR does / why we need it:

#### Special notes for your reviewer:

#### Additional documentation or context
