### PR TITLE
GetDiskStatus: return *types.DiskStatus rather than a json string

### DIFF
--- a/app/cmd/spdksetup/spdksetup.go
+++ b/app/cmd/spdksetup/spdksetup.go
@@ -1,6 +1,7 @@
 package spdksetup
 
 import (
+	"encoding/json"
 	"fmt"
 
 	"github.com/sirupsen/logrus"
@@ -139,7 +140,12 @@ func diskStatusCmd(c *cli.Context) error {
 
 	deviceAddr := c.Args().First()
 
-	output, err := spdksetup.GetDiskStatus(deviceAddr, executor)
+	status, err := spdksetup.GetDiskStatus(deviceAddr, executor)
+	if err != nil {
+		return err
+	}
+
+	output, err := json.Marshal(status)
 	if err != nil {
 		return err
 	}

--- a/pkg/spdk/setup/setup.go
+++ b/pkg/spdk/setup/setup.go
@@ -1,10 +1,12 @@
 package setup
 
 import (
+	"encoding/json"
 	"fmt"
 	"strings"
 
 	commonNs "github.com/longhorn/go-common-libs/ns"
+	"github.com/pkg/errors"
 
 	"github.com/longhorn/go-spdk-helper/pkg/types"
 )
@@ -74,9 +76,9 @@ func GetDiskDriver(deviceAddr string, executor *commonNs.Executor) (string, erro
 	return extractJSON(outputStr)
 }
 
-func GetDiskStatus(deviceAddr string, executor *commonNs.Executor) (string, error) {
+func GetDiskStatus(deviceAddr string, executor *commonNs.Executor) (*types.DiskStatus, error) {
 	if deviceAddr == "" {
-		return "", fmt.Errorf("device address is empty")
+		return nil, fmt.Errorf("device address is empty")
 	}
 
 	cmdArgs := []string{
@@ -87,10 +89,21 @@ func GetDiskStatus(deviceAddr string, executor *commonNs.Executor) (string, erro
 
 	outputStr, err := executor.Execute(nil, "bash", cmdArgs, types.ExecuteTimeout)
 	if err != nil {
-		return "", err
+		return nil, err
 	}
 
-	return extractJSON(outputStr)
+	jsonsStr, err := extractJSON(outputStr)
+	if err != nil {
+		return nil, err
+	}
+
+	var diskStatus types.DiskStatus
+	err = json.Unmarshal([]byte(jsonsStr), &diskStatus)
+	if err != nil {
+		return nil, errors.Wrapf(err, "failed to unmarshal disk status for %s", deviceAddr)
+	}
+
+	return &diskStatus, nil
 }
 
 func extractJSON(outputStr string) (string, error) {

--- a/pkg/types/types.go
+++ b/pkg/types/types.go
@@ -37,3 +37,13 @@ const (
 func GetNQN(name string) string {
 	return fmt.Sprintf("%s:%s", NQNPrefix, name)
 }
+
+type DiskStatus struct {
+	Bdf          string
+	Type         string
+	Driver       string
+	Vendor       string
+	Numa         string
+	Device       string
+	BlockDevices string
+}


### PR DESCRIPTION


#### Which issue(s) this PR fixes:
<!--
Use `Issue #<issue number>` or `Issue longhorn/longhorn#<issue number>` or `Issue (paste link of issue)`. DON'T use `Fixes #<issue number>` or `Fixes (paste link of issue)`, as it will automatically close the linked issue when the PR is merged.
-->
Issue Longhorn/longhorn#7672

#### What this PR does / why we need it:

#### Special notes for your reviewer:

#### Additional documentation or context
