### PR TITLE
Set multipath of nvmf controller to disable

### DIFF
--- a/app/cmd/basic/bdev_nvme.go
+++ b/app/cmd/basic/bdev_nvme.go
@@ -79,6 +79,11 @@ func BdevNvmeAttachControllerCmd() cli.Command {
 				Usage: "NVMe-oF keep alive timeout in milliseconds",
 				Value: types.DefaultKeepAliveTimeoutMs,
 			},
+			cli.StringFlag{
+				Name:  "multipath",
+				Usage: "Multipathing behavior: disable, failover, multipath. Default is failover",
+				Value: string(spdktypes.NvmeMultipathBehaviorFailover),
+			},
 		},
 		Action: func(c *cli.Context) {
 			if err := bdevNvmeAttachController(c); err != nil {
@@ -97,7 +102,8 @@ func bdevNvmeAttachController(c *cli.Context) error {
 	bdevNameList, err := spdkCli.BdevNvmeAttachController(c.String("name"), c.String("subnqn"),
 		c.String("traddr"), c.String("trsvcid"),
 		spdktypes.NvmeTransportType(c.String("trtype")), spdktypes.NvmeAddressFamily(c.String("adrfam")),
-		int32(c.Int("ctrlr-loss-timeout-sec")), int32(c.Int("reconnect-delay-sec")), int32(c.Int("fast-io-fail-timeout-sec")))
+		int32(c.Int("ctrlr-loss-timeout-sec")), int32(c.Int("reconnect-delay-sec")), int32(c.Int("fast-io-fail-timeout-sec")),
+		c.String("multipath"))
 	if err != nil {
 		return err
 	}

--- a/pkg/spdk/client/basic.go
+++ b/pkg/spdk/client/basic.go
@@ -576,7 +576,10 @@ func (c *Client) BdevRaidRemoveBaseBdev(name string) (removed bool, err error) {
 // "reconnectDelaySec": Controller reconnect delay in seconds
 //
 // "fastIOFailTimeoutSec": Fast I/O failure timeout in seconds
-func (c *Client) BdevNvmeAttachController(name, subnqn, traddr, trsvcid string, trtype spdktypes.NvmeTransportType, adrfam spdktypes.NvmeAddressFamily, ctrlrLossTimeoutSec, reconnectDelaySec, fastIOFailTimeoutSec int32) (bdevNameList []string, err error) {
+//
+// "multipath": Multipathing behavior: disable, failover, multipath. Default is failover
+func (c *Client) BdevNvmeAttachController(name, subnqn, traddr, trsvcid string, trtype spdktypes.NvmeTransportType, adrfam spdktypes.NvmeAddressFamily,
+	ctrlrLossTimeoutSec, reconnectDelaySec, fastIOFailTimeoutSec int32, multipath string) (bdevNameList []string, err error) {
 	req := spdktypes.BdevNvmeAttachControllerRequest{
 		Name: name,
 		NvmeTransportID: spdktypes.NvmeTransportID{
@@ -589,6 +592,7 @@ func (c *Client) BdevNvmeAttachController(name, subnqn, traddr, trsvcid string, 
 		CtrlrLossTimeoutSec:  ctrlrLossTimeoutSec,
 		ReconnectDelaySec:    reconnectDelaySec,
 		FastIOFailTimeoutSec: fastIOFailTimeoutSec,
+		Multipath:            multipath,
 	}
 
 	cmdOutput, err := c.jsonCli.SendCommand("bdev_nvme_attach_controller", req)

--- a/pkg/spdk/types/nvme.go
+++ b/pkg/spdk/types/nvme.go
@@ -18,6 +18,14 @@ const (
 	NvmeAddressFamilyIntraHost = NvmeAddressFamily("intra_host")
 )
 
+type NvmeMultipathBehavior string
+
+const (
+	NvmeMultipathBehaviorDisable   = "disable"
+	NvmeMultipathBehaviorFailover  = "failover"
+	NvmeMultipathBehaviorMultipath = "multipath"
+)
+
 type BdevDriverSpecificNvme []NvmeNamespaceInfo
 
 type NvmeNamespaceInfo struct {
@@ -99,6 +107,8 @@ type BdevNvmeAttachControllerRequest struct {
 	CtrlrLossTimeoutSec  int32 `json:"ctrlr_loss_timeout_sec"`
 	ReconnectDelaySec    int32 `json:"reconnect_delay_sec"`
 	FastIOFailTimeoutSec int32 `json:"fast_io_fail_timeout_sec"`
+
+	Multipath string `json:"multipath,omitempty"`
 }
 
 type BdevNvmeDetachControllerRequest struct {

--- a/pkg/types/types.go
+++ b/pkg/types/types.go
@@ -30,6 +30,7 @@ const (
 	DefaultTransportAckTimeout = 14
 
 	DefaultKeepAliveTimeoutMs = 10000
+	DefaultMultipath          = "disable"
 
 	ExecuteTimeout = 60 * time.Second
 )


### PR DESCRIPTION
#### Which issue(s) this PR fixes:
<!--
Use `Issue #<issue number>` or `Issue longhorn/longhorn#<issue number>` or `Issue (paste link of issue)`. DON'T use `Fixes #<issue number>` or `Fixes (paste link of issue)`, as it will automatically close the linked issue when the PR is merged.
-->
Issue Longhorn/longhorn#8354

#### What this PR does / why we need it:

Set multipath of nvmf controller to disable, because Longhorn doesn't reply on the multipath feature of the nvmf controller.

#### Special notes for your reviewer:

#### Additional documentation or context
