### PR TITLE
Add NGUID to NvmfSubsystemAddNs

### DIFF
--- a/app/cmd/advanced/expose.go
+++ b/app/cmd/advanced/expose.go
@@ -36,6 +36,11 @@ func StartExposeCmd() cli.Command {
 				Required: true,
 			},
 			cli.StringFlag{
+				Name:     "nguid",
+				Usage:    "Namespace globally unique identifier",
+				Required: false,
+			},
+			cli.StringFlag{
 				Name:     "ip",
 				Usage:    "This can be host IP or localhost IP",
 				Required: true,
@@ -60,7 +65,7 @@ func startExpose(c *cli.Context) error {
 		return err
 	}
 
-	if err := spdkCli.StartExposeBdev(c.String("nqn"), c.String("bdev-name"), c.String("ip"), c.String("port")); err != nil {
+	if err := spdkCli.StartExposeBdev(c.String("nqn"), c.String("bdev-name"), c.String("nguid"), c.String("ip"), c.String("port")); err != nil {
 		return err
 	}
 

--- a/app/cmd/basic/nvmf.go
+++ b/app/cmd/basic/nvmf.go
@@ -203,6 +203,11 @@ func NvmfSubsystemAddNsCmd() cli.Command {
 				Usage:    "Name of bdev to expose as a namespace",
 				Required: true,
 			},
+			cli.StringFlag{
+				Name:     "nguid",
+				Usage:    "Namespace globally unique identifier",
+				Required: false,
+			},
 		},
 		Usage: "add a bdev as a namespace for subsystem of nvmf: ns-add <SUBSYSTEM NQN>",
 		Action: func(c *cli.Context) {
@@ -219,7 +224,7 @@ func nvmfSubsystemAddNs(c *cli.Context) error {
 		return err
 	}
 
-	added, err := spdkCli.NvmfSubsystemAddNs(c.String("nqn"), c.String("bdev-name"))
+	added, err := spdkCli.NvmfSubsystemAddNs(c.String("nqn"), c.String("bdev-name"), c.String("nguid"))
 	if err != nil {
 		return err
 	}

--- a/pkg/spdk/client/advanced.go
+++ b/pkg/spdk/client/advanced.go
@@ -1,8 +1,9 @@
 package client
 
 import (
-	"github.com/longhorn/go-spdk-helper/pkg/jsonrpc"
 	"path/filepath"
+
+	"github.com/longhorn/go-spdk-helper/pkg/jsonrpc"
 
 	spdktypes "github.com/longhorn/go-spdk-helper/pkg/spdk/types"
 )
@@ -50,7 +51,7 @@ func (c *Client) DeleteDevice(bdevAioName, lvsName string) (err error) {
 	return nil
 }
 
-func (c *Client) StartExposeBdev(nqn, bdevName, ip, port string) error {
+func (c *Client) StartExposeBdev(nqn, bdevName, nguid, ip, port string) error {
 	nvmfTransportList, err := c.NvmfGetTransports("", "")
 	if err != nil {
 		return err
@@ -65,7 +66,7 @@ func (c *Client) StartExposeBdev(nqn, bdevName, ip, port string) error {
 		return err
 	}
 
-	if _, err := c.NvmfSubsystemAddNs(nqn, bdevName); err != nil {
+	if _, err := c.NvmfSubsystemAddNs(nqn, bdevName, nguid); err != nil {
 		return err
 	}
 

--- a/pkg/spdk/client/basic.go
+++ b/pkg/spdk/client/basic.go
@@ -798,10 +798,15 @@ func (c *Client) NvmfGetSubsystems(nqn, tgtName string) (subsystemList []spdktyp
 //	"nqn": Required. Subsystem NQN.
 //
 //	"bdevName": Required. Name of bdev to expose as a namespace.
-func (c *Client) NvmfSubsystemAddNs(nqn, bdevName string) (nsid uint32, err error) {
+//
+//	"nguid": Optional. Namespace globally unique identifier.
+func (c *Client) NvmfSubsystemAddNs(nqn, bdevName, nguid string) (nsid uint32, err error) {
 	req := spdktypes.NvmfSubsystemAddNsRequest{
-		Nqn:       nqn,
-		Namespace: spdktypes.NvmfSubsystemNamespace{BdevName: bdevName},
+		Nqn: nqn,
+		Namespace: spdktypes.NvmfSubsystemNamespace{
+			BdevName: bdevName,
+			Nguid:    nguid,
+		},
 	}
 
 	cmdOutput, err := c.jsonCli.SendCommand("nvmf_subsystem_add_ns", req)

--- a/pkg/spdk/spdk_test.go
+++ b/pkg/spdk/spdk_test.go
@@ -286,7 +286,7 @@ func (s *TestSuite) TestSPDKBasic(c *C) {
 	c.Assert(raidBdev.DriverSpecific.Raid.BaseBdevsList[1].IsConfigured, Equals, true)
 
 	nqn := types.GetNQN(raidName)
-	err = spdkCli.StartExposeBdev(nqn, raidName, types.LocalIP, defaultPort1)
+	err = spdkCli.StartExposeBdev(nqn, raidName, "ABCDEF0123456789ABCDEF0123456789", types.LocalIP, defaultPort1)
 	c.Assert(err, IsNil)
 	defer func() {
 		err = spdkCli.StopExposeBdev(nqn)


### PR DESCRIPTION


#### Which issue(s) this PR fixes:
<!--
Use `Issue #<issue number>` or `Issue longhorn/longhorn#<issue number>` or `Issue (paste link of issue)`. DON'T use `Fixes #<issue number>` or `Fixes (paste link of issue)`, as it will automatically close the linked issue when the PR is merged.
-->
Issue longhorn/longhorn#8551

#### What this PR does / why we need it:

To expose a logical volume and attach it to the local node, NGUID should be provided.


#### Special notes for your reviewer:

#### Additional documentation or context
