### PR TITLE
fix(lvol): set user_created to true if no xattr found

### DIFF
--- a/pkg/spdk/client/basic.go
+++ b/pkg/spdk/client/basic.go
@@ -2,6 +2,7 @@ package client
 
 import (
 	"encoding/json"
+	"strconv"
 	"strings"
 
 	"github.com/pkg/errors"
@@ -273,6 +274,8 @@ func (c *Client) BdevLvolGet(name string, timeout uint64) (bdevLvolInfoList []sp
 		user_created, err := c.BdevLvolGetXattr(b.Name, UserCreated)
 		if err == nil {
 			b.DriverSpecific.Lvol.Xattrs[UserCreated] = user_created
+		} else {
+			b.DriverSpecific.Lvol.Xattrs[UserCreated] = strconv.FormatBool(true)
 		}
 		snapshot_timestamp, err := c.BdevLvolGetXattr(b.Name, SnapshotTimestamp)
 		if err == nil {

--- a/pkg/spdk/spdk_test.go
+++ b/pkg/spdk/spdk_test.go
@@ -181,7 +181,7 @@ func (s *TestSuite) TestSPDKBasic(c *C) {
 		if lvol.UUID == lvolUUID2 {
 			c.Assert(lvol.Aliases[0], Equals, fmt.Sprintf("%s/%s", lvsName, lvolName2))
 		}
-		c.Assert(lvol.DriverSpecific.Lvol.Xattrs[client.UserCreated], Equals, "")
+		c.Assert(lvol.DriverSpecific.Lvol.Xattrs[client.UserCreated], Equals, "true")
 		c.Assert(lvol.DriverSpecific.Lvol.Xattrs[client.SnapshotTimestamp], Equals, "")
 	}
 
@@ -226,7 +226,7 @@ func (s *TestSuite) TestSPDKBasic(c *C) {
 	c.Assert(cloneLvol1.DriverSpecific.Lvol, NotNil)
 	c.Assert(cloneLvol1.DriverSpecific.Lvol.Snapshot, Equals, false)
 	c.Assert(cloneLvol1.DriverSpecific.Lvol.Clone, Equals, true)
-	c.Assert(cloneLvol1.DriverSpecific.Lvol.Xattrs[client.UserCreated], Equals, "")
+	c.Assert(cloneLvol1.DriverSpecific.Lvol.Xattrs[client.UserCreated], Equals, "true")
 	c.Assert(cloneLvol1.DriverSpecific.Lvol.Xattrs[client.SnapshotTimestamp], Equals, "")
 
 	decoupled, err := spdkCli.BdevLvolDecoupleParent(cloneLvolUUID1)


### PR DESCRIPTION
This is needed when upgrading from a version without the user_created xattr to a new one with this flag. Otherwise, the snapshot will not be listed in the UI.

#### Which issue(s) this PR fixes:
<!--
Use `Issue #<issue number>` or `Issue longhorn/longhorn#<issue number>` or `Issue (paste link of issue)`. DON'T use `Fixes #<issue number>` or `Fixes (paste link of issue)`, as it will automatically close the linked issue when the PR is merged.
-->
Issue longhorn/longhorn#9054

#### What this PR does / why we need it:

#### Special notes for your reviewer:

#### Additional documentation or context
