### PR TITLE
feat(nvmf): decrease reconnect-delay-sec to 2 seconds

### DIFF
--- a/pkg/types/types.go
+++ b/pkg/types/types.go
@@ -24,7 +24,7 @@ const (
 
 	DefaultCtrlrLossTimeoutSec = 30
 	// DefaultReconnectDelaySec can't be more than DefaultFastIoFailTimeoutSec, same for non-default values.
-	DefaultReconnectDelaySec    = 5
+	DefaultReconnectDelaySec    = 2
 	DefaultFastIOFailTimeoutSec = 15
 	// DefaultTransportAckTimeout value is not the timeout second.
 	// The timeout formula is 2^(transport_ack_timeout) msec.


### PR DESCRIPTION



#### Which issue(s) this PR fixes:
<!--
Use `Issue #<issue number>` or `Issue longhorn/longhorn#<issue number>` or `Issue (paste link of issue)`. DON'T use `Fixes #<issue number>` or `Fixes (paste link of issue)`, as it will automatically close the linked issue when the PR is merged.
-->
Issue Longhorn/longhorn#9190

#### What this PR does / why we need it:

Allows to re-establish the connection more quickly and prevent long stuck.

#### Special notes for your reviewer:

#### Additional documentation or context
