### PR TITLE
feat: decrease the reconnect delay of v2 volume nvme initiator

### DIFF
--- a/pkg/nvme/nvmecli.go
+++ b/pkg/nvme/nvmecli.go
@@ -19,7 +19,7 @@ const (
 	// Set short ctrlLossTimeoutSec for quick response to the controller loss.
 	defaultCtrlLossTmo    = 30
 	defaultKeepAliveTmo   = 5
-	defaultReconnectDelay = 10
+	defaultReconnectDelay = 2
 )
 
 type Device struct {


### PR DESCRIPTION


#### Which issue(s) this PR fixes:
<!--
Use `Issue #<issue number>` or `Issue longhorn/longhorn#<issue number>` or `Issue (paste link of issue)`. DON'T use `Fixes #<issue number>` or `Fixes (paste link of issue)`, as it will automatically close the linked issue when the PR is merged.
-->
Issue Longhorn/longhorn#9818

#### What this PR does / why we need it:

The current default value for --reconnect-delay is 10 seconds. We can reduce this value to 2 seconds.

- Advantages: Faster IO resumption post-upgrade
- Disadvantages: Increased frequency of retries


#### Special notes for your reviewer:

#### Additional documentation or context
