### PR TITLE
feat(backingimage): support v2 backing image

### DIFF
--- a/app/cmd/basic/bdev_lvol.go
+++ b/app/cmd/basic/bdev_lvol.go
@@ -396,11 +396,11 @@ func BdevLvolResizeCmd() cli.Command {
 				Usage: "Specify this or alias",
 			},
 			cli.Uint64Flag{
-				Name:     "size",
+				Name:     "size-in-mib",
 				Required: true,
 			},
 		},
-		Usage: "resize a lvol to a new size: \"resize --alias <LVSTORE NAME>/<LVOL NAME> --size <SIZE>\", or \"resize --uuid <LVOL UUID> --size <SIZE>\"",
+		Usage: "resize a lvol to a new size: \"resize --alias <LVSTORE NAME>/<LVOL NAME> --size-in-mib <SIZE>\", or \"resize --uuid <LVOL UUID> --size-in-mib <SIZE>\"",
 		Action: func(c *cli.Context) {
 			if err := bdevLvolResize(c); err != nil {
 				logrus.WithError(err).Fatalf("Failed to run resize bdev lvol command")
@@ -420,7 +420,7 @@ func bdevLvolResize(c *cli.Context) error {
 		name = c.String("uuid")
 	}
 
-	resized, err := spdkCli.BdevLvolResize(name, c.Uint64("size"))
+	resized, err := spdkCli.BdevLvolResize(name, c.Uint64("size-in-mib"))
 	if err != nil {
 		return err
 	}

--- a/app/cmd/nvmecli/nvmecli.go
+++ b/app/cmd/nvmecli/nvmecli.go
@@ -105,7 +105,7 @@ func ConnectCmd() cli.Command {
 }
 
 func connect(c *cli.Context) error {
-	executor, err := util.NewExecutor(c.String("host-proc"))
+	executor, err := util.NewExecutor(c.GlobalString("host-proc"))
 	if err != nil {
 		return err
 	}
@@ -131,7 +131,7 @@ func DisconnectCmd() cli.Command {
 }
 
 func disconnect(c *cli.Context) error {
-	executor, err := util.NewExecutor(c.String("host-proc"))
+	executor, err := util.NewExecutor(c.GlobalString("host-proc"))
 	if err != nil {
 		return err
 	}
@@ -167,7 +167,7 @@ func GetCmd() cli.Command {
 }
 
 func get(c *cli.Context) error {
-	executor, err := util.NewExecutor(c.String("host-proc"))
+	executor, err := util.NewExecutor(c.GlobalString("host-proc"))
 	if err != nil {
 		return err
 	}
@@ -216,7 +216,7 @@ func StartCmd() cli.Command {
 }
 
 func start(c *cli.Context) error {
-	initiator, err := nvme.NewInitiator(c.String("name"), c.String("nqn"), c.String("host-proc"))
+	initiator, err := nvme.NewInitiator(c.String("name"), c.String("nqn"), c.GlobalString("host-proc"))
 	if err != nil {
 		return err
 	}
@@ -257,7 +257,7 @@ func StopCmd() cli.Command {
 }
 
 func stop(c *cli.Context) error {
-	initiator, err := nvme.NewInitiator(c.String("name"), c.String("nqn"), c.String("host-proc"))
+	initiator, err := nvme.NewInitiator(c.String("name"), c.String("nqn"), c.GlobalString("host-proc"))
 	if err != nil {
 		return err
 	}
@@ -289,7 +289,7 @@ func FlushCmd() cli.Command {
 }
 
 func flush(c *cli.Context) error {
-	executor, err := util.NewExecutor(c.String("host-proc"))
+	executor, err := util.NewExecutor(c.GlobalString("host-proc"))
 	if err != nil {
 		return err
 	}

--- a/pkg/spdk/client/basic.go
+++ b/pkg/spdk/client/basic.go
@@ -412,11 +412,11 @@ func (c *Client) BdevLvolSetParent(lvol, parent string) (set bool, err error) {
 //
 //	"name": Required. UUID or alias of the logical volume to resize.
 //
-//	"size": Required. Desired size of the logical volume in bytes.
-func (c *Client) BdevLvolResize(name string, size uint64) (resized bool, err error) {
+//	"sizeInMib": Required. Desired size of the logical volume in bytes.
+func (c *Client) BdevLvolResize(name string, sizeInMib uint64) (resized bool, err error) {
 	req := spdktypes.BdevLvolResizeRequest{
-		Name: name,
-		Size: size,
+		Name:      name,
+		SizeInMib: sizeInMib,
 	}
 
 	cmdOutput, err := c.jsonCli.SendCommand("bdev_lvol_resize", req)

--- a/pkg/spdk/types/lvol.go
+++ b/pkg/spdk/types/lvol.go
@@ -130,8 +130,8 @@ type BdevLvolSetParentRequest struct {
 }
 
 type BdevLvolResizeRequest struct {
-	Name string `json:"name"`
-	Size uint64 `json:"size"`
+	Name      string `json:"name"`
+	SizeInMib uint64 `json:"size_in_mib"`
 }
 
 type BdevLvolShallowCopyRequest struct {


### PR DESCRIPTION
ref: https://github.com/longhorn/longhorn/issues/6341

- Fix `resize` command: https://spdk.io/doc/jsonrpc.html
```
## bdev_lvol_resize

Example request:
{
  "jsonrpc": "2.0",
  "method": "bdev_lvol_resize",
  "id": 1,
  "params": {
    "name": "51638754-ca16-43a7-9f8f-294a0805ab0a",
    "size_in_mib": 2
  }
}
Example response:

{
  "jsonrpc": "2.0",
  "id": 1,
  "result": true
}
```
- Fix `nvmecli` to use `c.GlobalString` instead of `c.String`