### PR TITLE
fix: improve lvol snapshot checksum get

### DIFF
--- a/app/cmd/basic/bdev_lvol.go
+++ b/app/cmd/basic/bdev_lvol.go
@@ -743,9 +743,9 @@ func bdevLvolGetSnapshotChecksum(c *cli.Context) error {
 	if err != nil {
 		return fmt.Errorf("failed to get checksum for snapshot %q: %v", name, err)
 	}
-	if checksum == nil {
+	if checksum == "" {
 		return fmt.Errorf("no checksum found for snapshot %q", name)
 	}
 
-	return util.PrintObject(*checksum)
+	return util.PrintObject(checksum)
 }


### PR DESCRIPTION
#### Which issue(s) this PR fixes:
<!--
Use `Issue #<issue number>` or `Issue longhorn/longhorn#<issue number>` or `Issue (paste link of issue)`. DON'T use `Fixes #<issue number>` or `Fixes (paste link of issue)`, as it will automatically close the linked issue when the PR is merged.
-->
Issue 
Longhorn/longhorn#8666
Longhorn/longhorn#9488

#### What this PR does / why we need it:
We need a convenient way to get all info of a snapshot lvol including its checksum.  For now, we can put the checksum in lvol xattr map.

#### Special notes for your reviewer:

#### Additional documentation or context
