### PR TITLE
fix: extend command timeout to 180 secs

### DIFF
--- a/pkg/types/types.go
+++ b/pkg/types/types.go
@@ -23,7 +23,7 @@ const (
 	ShallowCopyStateComplete   = "complete"
 	ShallowCopyStateError      = "error"
 
-	ExecuteTimeout = 60 * time.Second
+	ExecuteTimeout = 180 * time.Second
 )
 
 const (


### PR DESCRIPTION
ref: https://github.com/longhorn/longhorn/issues/10520

related:
- https://github.com/longhorn/longhorn/issues/10044
- https://github.com/longhorn/longhorn/issues/10522

sometimes initiator.stop() cannot be finished in 60 secs, we then unexpose the target which makes the nvme disconnect command stuck forever.
The hanging command can prevent the container from terminating and make the uninstallation fail.