### PR TITLE
chore(workflow): mount hugetlbfs if it doesn't exist and use OCI runners

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -7,7 +7,7 @@ on:
 jobs:
   build-amd64:
     name: Build AMD64 binaries
-    runs-on: longhorn-infra-amd64-runners
+    runs-on: longhorn-infra-oracle-amd64-spdk-runners
     steps:
     - name: Checkout code
       uses: actions/checkout@v4
@@ -29,7 +29,7 @@ jobs:
 
   build-arm64:
     name: Build ARM64 binaries
-    runs-on: longhorn-infra-arm64-runners
+    runs-on: longhorn-infra-oracle-arm64-spdk-runners
     steps:
     - name: Checkout code
       uses: actions/checkout@v4

--- a/scripts/test
+++ b/scripts/test
@@ -16,6 +16,14 @@ echo "Hugepages configured: $hugepages"
 
 mount --rbind /host/dev /dev
 mount --rbind /host/sys /sys
+
+echo "Checking /dev/hugepages"
+if [ ! -d /dev/hugepages ]; then
+  echo "Creating /dev/hugepages"
+  mkdir -p /dev/hugepages
+  mount -t hugetlbfs nodev /dev/hugepages
+fi
+
 trap "umount /dev && umount /sys" EXIT
 
 


### PR DESCRIPTION
#### Which issue(s) this PR fixes:
<!--
Use `Issue #<issue number>` or `Issue longhorn/longhorn#<issue number>` or `Issue (paste link of issue)`. DON'T use `Fixes #<issue number>` or `Fixes (paste link of issue)`, as it will automatically close the linked issue when the PR is merged.
-->
Issue longhorn/longhorn#10497

#### What this PR does / why we need it:

- mount hugetlbfs if it doesn't exist
- use OCI runners

#### Special notes for your reviewer:

#### Additional documentation or context
