### PR TITLE
feat: implement ublk frontend for v2 data engine - part 2

### DIFF
--- a/app/cmd/basic/ublk.go
+++ b/app/cmd/basic/ublk.go
@@ -97,7 +97,7 @@ func ublkGetDisks(c *cli.Context) error {
 	if err != nil {
 		return err
 	}
-	resp, err := spdkCli.UblkGetDisks(c.Int("ublk-id"))
+	resp, err := spdkCli.UblkGetDisks(int32(c.Int("ublk-id")))
 	if err != nil {
 		return err
 	}
@@ -143,7 +143,7 @@ func ublkStartDisk(c *cli.Context) error {
 	if err != nil {
 		return err
 	}
-	return spdkCli.UblkStartDisk(c.String("bdev-name"), c.Int("ublk-id"), c.Int("queue-depth"), c.Int("num-queues"))
+	return spdkCli.UblkStartDisk(c.String("bdev-name"), int32(c.Int("ublk-id")), int32(c.Int("queue-depth")), int32(c.Int("num-queues")))
 }
 
 func UblkRecoverDiskCmd() cli.Command {
@@ -175,7 +175,7 @@ func ublkRecoverDisk(c *cli.Context) error {
 	if err != nil {
 		return err
 	}
-	return spdkCli.UblkRecoverDisk(c.String("bdev-name"), c.Int("ublk-id"))
+	return spdkCli.UblkRecoverDisk(c.String("bdev-name"), int32(c.Int("ublk-id")))
 }
 
 func UblkStopDiskCmd() cli.Command {
@@ -202,5 +202,5 @@ func ublkStopDisk(c *cli.Context) error {
 	if err != nil {
 		return err
 	}
-	return spdkCli.UblkStopDisk(c.Int("ublk-id"))
+	return spdkCli.UblkStopDisk(int32(c.Int("ublk-id")))
 }

--- a/pkg/initiator/initiator.go
+++ b/pkg/initiator/initiator.go
@@ -73,7 +73,7 @@ type NVMeTCPInfo struct {
 
 type UblkInfo struct {
 	BdevName string
-	UblkID   int
+	UblkID   int32
 }
 
 // NewInitiator creates a new initiator

--- a/pkg/initiator/ublk_id_generator.go
+++ b/pkg/initiator/ublk_id_generator.go
@@ -9,21 +9,21 @@ import (
 // IDGenerator tracks only the last ID returned (which is never 0).
 // Valid range for returned IDs is [1..MaxUblkId].
 type IDGenerator struct {
-	lastCandidate int
+	lastCandidate int32
 }
 
 // GetAvailableID returns an ID in [1..65535] that is NOT in inUseUblkDeviceList.
 // We do a circular search, skipping ID=0 entirely.
 // This function is not thread safe. Caller need to have their own locking mechanism
-func (gen *IDGenerator) GetAvailableID(inUseUblkDeviceList []spdktypes.UblkDevice) (int, error) {
+func (gen *IDGenerator) GetAvailableID(inUseUblkDeviceList []spdktypes.UblkDevice) (int32, error) {
 	// Make a set for quick membership checks
-	inUsedMap := make(map[int]struct{}, len(inUseUblkDeviceList))
+	inUsedMap := make(map[int32]struct{}, len(inUseUblkDeviceList))
 	for _, ublkDevice := range inUseUblkDeviceList {
 		inUsedMap[ublkDevice.ID] = struct{}{}
 	}
 
 	// We'll try up to MaxUblkId times, because 0 is excluded
-	for i := 1; i <= MaxUblkId; i++ {
+	for i := int32(1); i <= MaxUblkId; i++ {
 		candidate := (gen.lastCandidate + i) & 0xFFFF // same as % 65536, but faster with bitwise
 		if candidate == 0 {
 			continue

--- a/pkg/spdk/client/ublk.go
+++ b/pkg/spdk/client/ublk.go
@@ -30,7 +30,7 @@ func (c *Client) UblkDestroyTarget() (err error) {
 }
 
 // UblkGetDisks displays full or specified ublk device list
-func (c *Client) UblkGetDisks(ublkID int) (ublkDeviceList []spdktypes.UblkDevice, err error) {
+func (c *Client) UblkGetDisks(ublkID int32) (ublkDeviceList []spdktypes.UblkDevice, err error) {
 	req := spdktypes.UblkGetDisksRequest{
 		UblkId: ublkID,
 	}
@@ -41,7 +41,7 @@ func (c *Client) UblkGetDisks(ublkID int) (ublkDeviceList []spdktypes.UblkDevice
 	return ublkDeviceList, json.Unmarshal(cmdOutput, &ublkDeviceList)
 }
 
-func (c *Client) UblkStartDisk(bdevName string, ublkId, queueDepth, numQueues int) (err error) {
+func (c *Client) UblkStartDisk(bdevName string, ublkId, queueDepth, numQueues int32) (err error) {
 	req := spdktypes.UblkStartDiskRequest{
 		BdevName:   bdevName,
 		UblkId:     ublkId,
@@ -55,7 +55,7 @@ func (c *Client) UblkStartDisk(bdevName string, ublkId, queueDepth, numQueues in
 	return nil
 }
 
-func (c *Client) UblkRecoverDisk(bdevName string, ublkId int) (err error) {
+func (c *Client) UblkRecoverDisk(bdevName string, ublkId int32) (err error) {
 	req := spdktypes.UblkRecoverDiskRequest{
 		BdevName: bdevName,
 		UblkId:   ublkId,
@@ -67,7 +67,7 @@ func (c *Client) UblkRecoverDisk(bdevName string, ublkId int) (err error) {
 	return nil
 }
 
-func (c *Client) UblkStopDisk(ublkId int) (err error) {
+func (c *Client) UblkStopDisk(ublkId int32) (err error) {
 	req := spdktypes.UblkStopDiskRequest{
 		UblkId: ublkId,
 	}
@@ -78,7 +78,7 @@ func (c *Client) UblkStopDisk(ublkId int) (err error) {
 	return nil
 }
 
-func (c *Client) FindUblkDevicePath(ublkID int) (string, error) {
+func (c *Client) FindUblkDevicePath(ublkID int32) (string, error) {
 	ublkDeviceList, err := c.UblkGetDisks(ublkID)
 	if err != nil {
 		return "", err

--- a/pkg/spdk/types/ublk.go
+++ b/pkg/spdk/types/ublk.go
@@ -6,29 +6,29 @@ type UblkCreateTargetRequest struct {
 }
 
 type UblkGetDisksRequest struct {
-	UblkId int `json:"ublk_id"`
+	UblkId int32 `json:"ublk_id"`
 }
 
 type UblkDevice struct {
 	BdevName   string `json:"bdev_name"`
-	ID         int    `json:"id"`
-	NumQueues  int    `json:"num_queues"`
-	QueueDepth int    `json:"queue_depth"`
+	ID         int32  `json:"id"`
+	NumQueues  int32  `json:"num_queues"`
+	QueueDepth int32  `json:"queue_depth"`
 	UblkDevice string `json:"ublk_device"`
 }
 
 type UblkStartDiskRequest struct {
 	BdevName   string `json:"bdev_name"`
-	UblkId     int    `json:"ublk_id"`
-	QueueDepth int    `json:"queue_depth"`
-	NumQueues  int    `json:"num_queues"`
+	UblkId     int32  `json:"ublk_id"`
+	QueueDepth int32  `json:"queue_depth"`
+	NumQueues  int32  `json:"num_queues"`
 }
 
 type UblkRecoverDiskRequest struct {
 	BdevName string `json:"bdev_name"`
-	UblkId   int    `json:"ublk_id"`
+	UblkId   int32  `json:"ublk_id"`
 }
 
 type UblkStopDiskRequest struct {
-	UblkId int `json:"ublk_id"`
+	UblkId int32 `json:"ublk_id"`
 }


### PR DESCRIPTION
Change ublkd to use int32 so that it is consistent with other fields

longhorn/longhorn#9456

